### PR TITLE
Potential fix for code scanning alert no. 1: Inefficient regular expression

### DIFF
--- a/packages/vscode/src/commands/apply-changes-command/clipboard-parser.ts
+++ b/packages/vscode/src/commands/apply-changes-command/clipboard-parser.ts
@@ -10,7 +10,7 @@ const extract_filename_from_comment = (line: string): string | null => {
     .replace(/^(\/\/|#|--|\/\*|\*)\s*/, '')
     .trim()
 
-  const path_match = stripped.match(/(?:[\w\-\.\/]+\/)*[\w\-\.]+\.\w{1,10}/)
+  const path_match = stripped.match(/(?:[a-zA-Z0-9_.-]+\/)*[a-zA-Z0-9_.-]+\.\w{1,10}/)
   if (path_match && path_match[0]) {
     return path_match[0]
   }


### PR DESCRIPTION
Potential fix for [https://github.com/GaxGuy/gemini-coder/security/code-scanning/1](https://github.com/GaxGuy/gemini-coder/security/code-scanning/1)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. We can achieve this by making the sub-expressions more specific and less prone to multiple matching paths. Specifically, we can replace `[\w\-\.\/]+` with a more precise pattern that avoids ambiguity.

- The best way to fix the problem is to use a non-capturing group with a more specific pattern that matches valid file path characters without causing ambiguity.
- We will replace the regular expression on line 13 with a more efficient version that avoids exponential backtracking.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
